### PR TITLE
[Bugfix] Pass snapToMins to _DurationPickerDialog in showDurationPicker(..)

### DIFF
--- a/lib/flutter_duration_picker.dart
+++ b/lib/flutter_duration_picker.dart
@@ -575,7 +575,7 @@ Future<Duration> showDurationPicker(
   return await showDialog<Duration>(
     context: context,
     builder: (BuildContext context) =>
-        new _DurationPickerDialog(initialTime: initialTime),
+        new _DurationPickerDialog(initialTime: initialTime, snapToMins: snapToMins),
   );
 }
 


### PR DESCRIPTION
Hey, when i tried to use snapToMins with the dialog, I found out that the value is not passed to the picker widget constructor. Here is a fix!
Great work, really helped me out with this duration picker!
Regards.