### PR TITLE
Clock background work for both LIGHT and DARK theme now

### DIFF
--- a/lib/flutter_duration_picker.dart
+++ b/lib/flutter_duration_picker.dart
@@ -73,7 +73,7 @@ class _DialPainter extends CustomPainter {
 
     // Draw the inner background circle
     canvas.drawCircle(
-        centerPoint, radius * 0.88, new Paint()..color = Colors.white);
+        centerPoint, radius * 0.88, new Paint()..color = Theme.of(context).canvasColor);
 
     // Get the offset point for an angle value of theta, and a distance of _radius
     Offset getOffsetForTheta(double theta, double _radius) {


### PR DESCRIPTION
See the issue
[https://github.com/cdharris/issues/10]

The clock always paints the background circle as white even if the brightness of the app is set to dark.
This commit solves the issue,