### PR TITLE
Issue #28 - Method not found: 'ButtonTheme.bar'

### DIFF
--- a/lib/flutter_duration_picker.dart
+++ b/lib/flutter_duration_picker.dart
@@ -576,7 +576,8 @@ class _DurationPickerDialogState extends State<_DurationPickerDialog> {
               snapToMins: widget.snapToMins,
             )));
 
-    final Widget actions = new ButtonTheme.bar(
+    final Widget actions = new ButtonBarTheme(
+        data: ButtonBarTheme.of(context),
         child: new ButtonBar(children: <Widget>[
           new FlatButton(
               child: new Text(localizations.cancelButtonLabel),


### PR DESCRIPTION
Solution for issue #28

Error Stacktrace :

```
../../../../../../../../../.pub-cache/hosted/pub.dartlang.org/flutter_duration_picker-1.0.4/lib/flutter_duration_picker.dart:506:44: Error: Method not found: 'ButtonTheme.bar'.
    final Widget actions = new ButtonTheme.bar(
                                                         ^^^
```



As per SO post : https://stackoverflow.com/questions/66027441/error-method-not-found-buttontheme-bar

ButtonTheme.bar is Deprecated. We need to use ButtonBarTheme instead which offers more flexibility to configure ButtonBar widgets. This feature was deprecated after v1.9.1.

So need to change

final Widget actions = new ButtonTheme.bar(

to

final Widget actions = new ButtonBarTheme(
  data: ButtonBarTheme.of(context),

on line 579 of flutter_duration_picker.dart